### PR TITLE
Release/1.0.1

### DIFF
--- a/k8s-aws-auth.tf
+++ b/k8s-aws-auth.tf
@@ -36,4 +36,6 @@ resource "kubernetes_config_map" "aws_auth" {
       users = coalesce(try(var.aws_auth.map_users, null), [])
     })
   }
+
+  depends_on = [aws_eks_cluster.cluster]
 }


### PR DESCRIPTION
Add missing `depends_on` argument to the aws_auth resource.

This should have been here before, but I suppose I left it out after I shuffled things for testing.