### PR TITLE
Release/1.2.0

### DIFF
--- a/_data.tf
+++ b/_data.tf
@@ -1,9 +1,11 @@
 data "aws_eks_cluster_auth" "auth" {
-  name = aws_eks_cluster.cluster.name
+  count = var.create ? 1 : 0
+
+  name = aws_eks_cluster.cluster[0].name
 }
 
 data "tls_certificate" "cluster" {
-  count = coalesce(try(var.iam.create_oidc_provider, null), true) ? 1 : 0
+  count = var.create && coalesce(try(var.iam.create_oidc_provider, null), true) ? 1 : 0
 
-  url = aws_eks_cluster.cluster.identity[0].oidc[0].issuer
+  url = aws_eks_cluster.cluster[0].identity[0].oidc[0].issuer
 }

--- a/_out.tf
+++ b/_out.tf
@@ -15,18 +15,23 @@ output "enabled_cluster_log_types" {
 
 output "cluster" {
   description = "The EKS cluster itself"
-  value       = aws_eks_cluster.cluster
+  value       = one(aws_eks_cluster.cluster)
 }
 
 output "cluster_auth" {
   description = "Kube API auth for the cluster"
-  value       = data.aws_eks_cluster_auth.auth
+  value       = one(data.aws_eks_cluster_auth.auth)
   sensitive   = true
 }
 
 output "cluster_role" {
   description = "The role created for use as the cluster role, if one wasn't provided"
   value       = one(aws_iam_role.cluster_role)
+}
+
+output "create" {
+  description = "The value provided for var.create"
+  value       = var.create
 }
 
 output "default_compute_subnet_ids" {
@@ -71,7 +76,7 @@ output "kubernetes_network_config" {
 
 output "log_group" {
   description = "The Cloudwatch log group created for cluster logs"
-  value       = aws_cloudwatch_log_group.logs
+  value       = one(aws_cloudwatch_log_group.logs)
 }
 
 output "name" {

--- a/_provider.tf
+++ b/_provider.tf
@@ -1,8 +1,5 @@
 provider "kubernetes" {
-  # host                   = try(aws_eks_cluster.cluster[0].endpoint, "https://jsonplaceholder.typicode.com")
-  # cluster_ca_certificate = try(base64decode(aws_eks_cluster.cluster[0].certificate_authority[0]["data"]), "")
-  # token                  = try(data.aws_eks_cluster_auth.auth[0].token, "")
-  host                   = aws_eks_cluster.cluster[0].endpoint
-  cluster_ca_certificate = base64decode(aws_eks_cluster.cluster[0].certificate_authority[0]["data"])
-  token                  = data.aws_eks_cluster_auth.auth[0].token
+  host                   = try(aws_eks_cluster.cluster[0].endpoint, "https://jsonplaceholder.typicode.com")
+  cluster_ca_certificate = try(base64decode(aws_eks_cluster.cluster[0].certificate_authority[0]["data"]), "")
+  token                  = try(data.aws_eks_cluster_auth.auth[0].token, "")
 }

--- a/_provider.tf
+++ b/_provider.tf
@@ -1,5 +1,5 @@
 provider "kubernetes" {
-  host                   = aws_eks_cluster.cluster.endpoint
-  cluster_ca_certificate = base64decode(aws_eks_cluster.cluster.certificate_authority[0]["data"])
-  token                  = data.aws_eks_cluster_auth.auth.token
+  host                   = try(aws_eks_cluster.cluster[0].endpoint, "https://jsonplaceholder.typicode.com")
+  cluster_ca_certificate = try(base64decode(aws_eks_cluster.cluster[0].certificate_authority[0]["data"]), "")
+  token                  = try(data.aws_eks_cluster_auth.auth[0].token, "")
 }

--- a/_provider.tf
+++ b/_provider.tf
@@ -1,5 +1,8 @@
 provider "kubernetes" {
-  host                   = try(aws_eks_cluster.cluster[0].endpoint, "https://jsonplaceholder.typicode.com")
-  cluster_ca_certificate = try(base64decode(aws_eks_cluster.cluster[0].certificate_authority[0]["data"]), "")
-  token                  = try(data.aws_eks_cluster_auth.auth[0].token, "")
+  # host                   = try(aws_eks_cluster.cluster[0].endpoint, "https://jsonplaceholder.typicode.com")
+  # cluster_ca_certificate = try(base64decode(aws_eks_cluster.cluster[0].certificate_authority[0]["data"]), "")
+  # token                  = try(data.aws_eks_cluster_auth.auth[0].token, "")
+  host                   = aws_eks_cluster.cluster[0].endpoint
+  cluster_ca_certificate = base64decode(aws_eks_cluster.cluster[0].certificate_authority[0]["data"])
+  token                  = data.aws_eks_cluster_auth.auth[0].token
 }

--- a/_var.tf
+++ b/_var.tf
@@ -28,6 +28,12 @@ variable "aws_auth" {
   default = null
 }
 
+variable "create" {
+  description = "Use to toggle creation of sources by this module"
+  type        = bool
+  default     = true
+}
+
 variable "default_compute_subnet_ids" {
   description = "IDs of subnets to use by default when creating node groups or fargate profiles"
   type        = list(string)

--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -1,4 +1,6 @@
 resource "aws_cloudwatch_log_group" "logs" {
+  count = var.create ? 1 : 0
+
   name = try(var.log_group.name_prefix, null) == null ? coalesce(
     try(var.log_group.name, null),
     "/aws/eks/${var.name}/cluster"

--- a/eks-addon.tf
+++ b/eks-addon.tf
@@ -1,9 +1,9 @@
 resource "aws_eks_addon" "addon" {
-  for_each = { for addon in var.addons : addon.name => addon }
+  for_each = var.create ? { for addon in var.addons : addon.name => addon } : {}
 
   addon_name               = each.value.name
   addon_version            = each.value.version
-  cluster_name             = aws_eks_cluster.cluster.name
+  cluster_name             = aws_eks_cluster.cluster[0].name
   resolve_conflicts        = each.value.resolve_conflicts
   service_account_role_arn = each.value.service_account_role_arn
 

--- a/eks-cluster.tf
+++ b/eks-cluster.tf
@@ -1,4 +1,6 @@
 resource "aws_eks_cluster" "cluster" {
+  count = var.create ? 1 : 0
+
   enabled_cluster_log_types = var.enabled_cluster_log_types
   name                      = var.name
   version                   = var.kubernetes_version
@@ -35,5 +37,5 @@ resource "aws_eks_cluster" "cluster" {
     "Managed By Terraform" = "true"
   })
 
-  depends_on = [aws_cloudwatch_log_group.logs]
+  depends_on = [aws_cloudwatch_log_group.logs[0]]
 }

--- a/eks-fargate-profile.tf
+++ b/eks-fargate-profile.tf
@@ -1,7 +1,7 @@
 resource "aws_eks_fargate_profile" "fargate_profile" {
-  for_each = { for fp in var.fargate_profiles : fp.name => fp }
+  for_each = var.create ? { for fp in var.fargate_profiles : fp.name => fp } : {}
 
-  cluster_name         = aws_eks_cluster.cluster.name
+  cluster_name         = aws_eks_cluster.cluster[0].name
   fargate_profile_name = each.value.name
 
   pod_execution_role_arn = coalesce(

--- a/eks-idp-config.tf
+++ b/eks-idp-config.tf
@@ -1,7 +1,7 @@
 resource "aws_eks_identity_provider_config" "identity" {
-  for_each = { for idp in var.identity_provider_config : idp.oidc.client_id => idp }
+  for_each = var.create ? { for idp in var.identity_provider_config : idp.oidc.client_id => idp } : {}
 
-  cluster_name = aws_eks_cluster.cluster.name
+  cluster_name = aws_eks_cluster.cluster[0].name
 
   oidc {
     client_id                     = each.value.oidc.client_id

--- a/eks-node-group.tf
+++ b/eks-node-group.tf
@@ -1,9 +1,9 @@
 resource "aws_eks_node_group" "node_group" {
-  for_each = { for ng in var.node_groups : ng.name => ng }
+  for_each = var.create ? { for ng in var.node_groups : ng.name => ng } : {}
 
   ami_type               = each.value.ami_type
   capacity_type          = each.value.capacity_type
-  cluster_name           = aws_eks_cluster.cluster.name
+  cluster_name           = aws_eks_cluster.cluster[0].name
   disk_size              = each.value.disk_size
   force_update_version   = each.value.force_update_version
   instance_types         = each.value.instance_types
@@ -16,7 +16,7 @@ resource "aws_eks_node_group" "node_group" {
   node_role_arn = coalesce(
     each.value.node_role_arn,
     try(var.iam.node_role.arn, null),
-    try(aws_iam_role.node_role.0.arn, null),
+    try(aws_iam_role.node_role[0].arn, null),
   )
 
   subnet_ids = coalesce(

--- a/iam-cluster-role.tf
+++ b/iam-cluster-role.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "cluster_role" {
-  count = try(var.iam.cluster_role.arn, null) == null ? 1 : 0
+  count = var.create && try(var.iam.cluster_role.arn, null) == null ? 1 : 0
 
   description = "Role used by the EKS cluster ${var.name}"
   name        = coalesce(try(var.iam.cluster_role.name, null), "eks-${var.name}-cluster")

--- a/iam-fargate-role.tf
+++ b/iam-fargate-role.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "fargate_role" {
-  count = try(var.iam.fargate_role.arn, null) == null && anytrue([
+  count = var.create && try(var.iam.fargate_role.arn, null) == null && anytrue([
     for fp in var.fargate_profiles : fp.pod_execution_role_arn == null
   ]) ? 1 : 0
 

--- a/iam-node-role.tf
+++ b/iam-node-role.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "node_role" {
-  count = try(var.iam.node_role.arn, null) == null && anytrue([
+  count = var.create && try(var.iam.node_role.arn, null) == null && anytrue([
     for ng in var.node_groups : ng.node_role_arn == null
   ]) ? 1 : 0
 

--- a/iam-oidc-provider.tf
+++ b/iam-oidc-provider.tf
@@ -1,7 +1,7 @@
 resource "aws_iam_openid_connect_provider" "cluster" {
-  count = coalesce(try(var.iam.create_oidc_provider, null), true) ? 1 : 0
+  count = var.create && coalesce(try(var.iam.create_oidc_provider, null), true) ? 1 : 0
 
   client_id_list  = ["sts.amazonaws.com"]
   thumbprint_list = [data.tls_certificate.cluster[0].certificates[0].sha1_fingerprint]
-  url             = aws_eks_cluster.cluster.identity[0].oidc[0].issuer
+  url             = aws_eks_cluster.cluster[0].identity[0].oidc[0].issuer
 }

--- a/k8s-aws-auth.tf
+++ b/k8s-aws-auth.tf
@@ -1,5 +1,5 @@
 resource "kubernetes_config_map" "aws_auth" {
-  count = coalesce(try(var.aws_auth.create, true), true) ? 1 : 0
+  count = var.create && coalesce(try(var.aws_auth.create, true), true) ? 1 : 0
 
   metadata {
     name      = "aws-auth"
@@ -37,5 +37,5 @@ resource "kubernetes_config_map" "aws_auth" {
     })
   }
 
-  depends_on = [aws_eks_cluster.cluster]
+  depends_on = [aws_eks_cluster.cluster[0]]
 }

--- a/kms.tf
+++ b/kms.tf
@@ -1,5 +1,5 @@
 resource "aws_kms_key" "key" {
-  count = try(var.encryption_config.provider.key_arn, null) == null ? 1 : 0
+  count = var.create && try(var.encryption_config.provider.key_arn, null) == null ? 1 : 0
 
   description = "Encrypts the contents of the EKS cluster ${var.name}"
 
@@ -10,8 +10,8 @@ resource "aws_kms_key" "key" {
 }
 
 resource "aws_kms_alias" "alias" {
-  count = try(var.encryption_config.provider.key_arn, null) == null ? 1 : 0
+  count = var.create && try(var.encryption_config.provider.key_arn, null) == null ? 1 : 0
 
   name          = "alias/eks-${var.name}"
-  target_key_id = aws_kms_key.key.0.arn
+  target_key_id = aws_kms_key.key[0].arn
 }


### PR DESCRIPTION
Add `var.create` so the module's resources can be toggled on or off.

Normally this would be done with the `count` meta-argument, but `count` can't be used for this module because it declares a Kubernetes provider.