### PR TITLE
Release/1.3.0

### DIFF
--- a/_provider.tf
+++ b/_provider.tf
@@ -1,5 +1,17 @@
 provider "kubernetes" {
   host                   = try(aws_eks_cluster.cluster[0].endpoint, "https://jsonplaceholder.typicode.com")
   cluster_ca_certificate = try(base64decode(aws_eks_cluster.cluster[0].certificate_authority[0]["data"]), "")
-  token                  = try(data.aws_eks_cluster_auth.auth[0].token, "")
+
+  token = coalesce(try(var.aws_auth.method, null), "exec") == "token" ? try(
+    data.aws_eks_cluster_auth.auth[0].token, ""
+  ) : null
+
+  dynamic "exec" {
+    for_each = coalesce(try(var.aws_auth.method, null), "exec") == "exec" ? [1] : []
+    content {
+      api_version = "client.authentication.k8s.io/v1alpha1"
+      args        = ["eks", "get-token", "--cluster-name", var.name]
+      command     = coalesce(try(var.aws_auth.exec_path, null), "/usr/local/bin/aws")
+    }
+  }
 }

--- a/_var.tf
+++ b/_var.tf
@@ -13,7 +13,8 @@ variable "addons" {
 variable "aws_auth" {
   description = "Configurations of the IAM authorizations for this cluster"
   type = object({
-    create = optional(bool)
+    create    = optional(bool)
+    exec_path = optional(string)
     map_roles = optional(list(object({
       rolearn  = string
       username = string
@@ -24,6 +25,7 @@ variable "aws_auth" {
       username = string
       groups   = list(string)
     })))
+    method = optional(string)
   })
   default = null
 }


### PR DESCRIPTION
Added variable attributes:

 - `var.aws_auth.method` to toggle provider authentication methods; valid values are `exec` or `token`
 - `var.aws_auth.exec_path` the path to the `aws` binary on the machine running Terraform; defaults to `/usr/local/bin/aws` because this works with Terraform Cloud/ Enterprise